### PR TITLE
Add noop interface generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,33 @@
+# noopito
+
+`noopito` is a small CLI utility that generates no-op implementations for Go interfaces. The tool is designed to work with `go generate` and is useful when you need stub implementations for testing or scaffolding.
+
+## Installation
+
+```bash
+go install ./cmd/noopito
+```
+
+## Usage
+
+Run the tool by specifying the package path and the interface name. By default, the generated file is written to the current directory.
+
+```bash
+noopito -package=your/module/pkg -interface=InterfaceName -output=./mocks
+```
+
+This will create `interfacename_noop.go` in the output directory containing a struct named `InterfaceNameNoOp` that implements all methods with zero-value returns.
+
+### Using `go generate`
+
+Add a `//go:generate` directive near the interface definition:
+
+```go
+//go:generate noopito -package=your/module/pkg -interface=InterfaceName -output=./mocks
+```
+
+Then run `go generate ./...` to produce the file automatically.
+
+## License
+
+MIT

--- a/cmd/noopito/main.go
+++ b/cmd/noopito/main.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"flag"
+	"log"
+
+	"github.com/AbdouB/noopito/internal/generator"
+)
+
+func main() {
+	pkg := flag.String("package", "", "package import path")
+	iface := flag.String("interface", "", "interface name")
+	outDir := flag.String("output", ".", "output directory")
+	flag.Parse()
+
+	if *pkg == "" || *iface == "" {
+		log.Fatal("package and interface flags are required")
+	}
+
+	if err := generator.GenerateNoOp(*pkg, *iface, *outDir); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,10 @@
+module github.com/AbdouB/noopito
+
+go 1.23.8
+
+require golang.org/x/tools v0.34.0
+
+require (
+	golang.org/x/mod v0.25.0 // indirect
+	golang.org/x/sync v0.15.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,8 @@
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+golang.org/x/mod v0.25.0 h1:n7a+ZbQKQA/Ysbyb0/6IbB1H/X41mKgbhfv7AfG/44w=
+golang.org/x/mod v0.25.0/go.mod h1:IXM97Txy2VM4PJ3gI61r1YEk/gAj6zAHN3AdZt6S9Ww=
+golang.org/x/sync v0.15.0 h1:KWH3jNZsfyT6xfAfKiz6MRNmd46ByHDYaZ7KSkCtdW8=
+golang.org/x/sync v0.15.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
+golang.org/x/tools v0.34.0 h1:qIpSLOxeCYGg9TrcJokLBG4KFA6d795g0xkBkiESGlo=
+golang.org/x/tools v0.34.0/go.mod h1:pAP9OwEaY1CAW3HOmg3hLZC5Z0CCmzjAF2UQMSqNARg=

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -1,0 +1,113 @@
+package generator
+
+import (
+	"bytes"
+	"fmt"
+	"go/format"
+	"go/types"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/tools/go/packages"
+)
+
+// GenerateNoOp generates a no-op implementation of interfaceName from pkgPath
+// and writes it to outputDir.
+func GenerateNoOp(pkgPath, interfaceName, outputDir string) error {
+	cfg := &packages.Config{Mode: packages.NeedTypes | packages.NeedTypesInfo | packages.NeedName | packages.NeedModule}
+	pkgs, err := packages.Load(cfg, pkgPath)
+	if err != nil {
+		return fmt.Errorf("loading package: %w", err)
+	}
+	if packages.PrintErrors(pkgs) > 0 {
+		return fmt.Errorf("package has errors")
+	}
+	if len(pkgs) == 0 {
+		return fmt.Errorf("package %s not found", pkgPath)
+	}
+	pkg := pkgs[0]
+	obj := pkg.Types.Scope().Lookup(interfaceName)
+	if obj == nil {
+		return fmt.Errorf("interface %s not found in package %s", interfaceName, pkgPath)
+	}
+	named, ok := obj.(*types.TypeName)
+	if !ok {
+		return fmt.Errorf("%s is not a type", interfaceName)
+	}
+	iface, ok := named.Type().Underlying().(*types.Interface)
+	if !ok {
+		return fmt.Errorf("%s is not an interface", interfaceName)
+	}
+	iface = iface.Complete()
+
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "package %s\n\n", pkg.Name)
+	implName := interfaceName + "NoOp"
+	fmt.Fprintf(&buf, "type %s struct{}\n\n", implName)
+
+	for i := 0; i < iface.NumMethods(); i++ {
+		m := iface.Method(i)
+		sig := m.Type().(*types.Signature)
+
+		params := make([]string, 0, sig.Params().Len())
+		for j := 0; j < sig.Params().Len(); j++ {
+			p := sig.Params().At(j)
+			name := p.Name()
+			if name == "" {
+				name = fmt.Sprintf("arg%d", j)
+			}
+			params = append(params, fmt.Sprintf("%s %s", name, typeString(p.Type())))
+		}
+		paramsStr := strings.Join(params, ", ")
+
+		results := make([]string, 0, sig.Results().Len())
+		for j := 0; j < sig.Results().Len(); j++ {
+			r := sig.Results().At(j)
+			tstr := typeString(r.Type())
+			if r.Name() != "" {
+				results = append(results, fmt.Sprintf("%s %s", r.Name(), tstr))
+			} else {
+				results = append(results, tstr)
+			}
+		}
+		resultsStr := strings.Join(results, ", ")
+		if len(results) > 1 {
+			resultsStr = "(" + resultsStr + ")"
+		}
+
+		fmt.Fprintf(&buf, "func (n %s) %s(%s) %s {\n", implName, m.Name(), paramsStr, resultsStr)
+		if sig.Results().Len() > 0 {
+			for j := 0; j < sig.Results().Len(); j++ {
+				r := sig.Results().At(j)
+				fmt.Fprintf(&buf, "\tvar r%d %s\n", j, typeString(r.Type()))
+			}
+			buf.WriteString("\treturn ")
+			for j := 0; j < sig.Results().Len(); j++ {
+				if j > 0 {
+					buf.WriteString(", ")
+				}
+				fmt.Fprintf(&buf, "r%d", j)
+			}
+			buf.WriteString("\n")
+		}
+		buf.WriteString("}\n\n")
+	}
+
+	formatted, err := format.Source(buf.Bytes())
+	if err != nil {
+		return fmt.Errorf("formatting code: %w", err)
+	}
+
+	outPath := filepath.Join(outputDir, fmt.Sprintf("%s_noop.go", strings.ToLower(interfaceName)))
+	return os.WriteFile(outPath, formatted, 0o644)
+}
+
+func typeString(t types.Type) string {
+	return types.TypeString(t, func(p *types.Package) string {
+		if p == nil {
+			return ""
+		}
+		return p.Name()
+	})
+}

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -1,0 +1,33 @@
+package generator
+
+import (
+	"go/format"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// define a sample interface for testing
+// this interface is part of the test package so we can load it by package path "github.com/AbdouB/noopito/internal/testpkg".
+type Example interface {
+	DoSomething(a int) error
+	Value() string
+}
+
+func TestGenerateNoOp(t *testing.T) {
+	dir := t.TempDir()
+	err := GenerateNoOp("github.com/AbdouB/noopito/internal/testpkg", "Example", dir)
+	if err != nil {
+		t.Fatalf("GenerateNoOp failed: %v", err)
+	}
+	outFile := filepath.Join(dir, "example_noop.go")
+	data, err := os.ReadFile(outFile)
+	if err != nil {
+		t.Fatalf("reading output: %v", err)
+	}
+	// attempt to format to ensure valid go code
+	_, err = format.Source(data)
+	if err != nil {
+		t.Fatalf("output is not valid go: %v", err)
+	}
+}

--- a/internal/testpkg/pkg.go
+++ b/internal/testpkg/pkg.go
@@ -1,0 +1,6 @@
+package testpkg
+
+type Example interface {
+	DoSomething(a int) error
+	Value() string
+}


### PR DESCRIPTION
## Summary
- implement `GenerateNoOp` without jennifer for plain code generation
- update import paths and module name to `github.com/AbdouB/noopito`
- remove Development section from README

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685b014f27988324af24fb163b4bec59