### PR TITLE
Add default package detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ go install ./cmd/noopito
 
 ## Usage
 
-Run the tool by specifying the package path and the interface name. By default, the generated file is written to the current directory.
+Run the tool by specifying the package path and the interface name. If the `-package` flag is omitted when running via `go generate`, the current package is used automatically. By default, the generated file is written to the current directory.
 
 ```bash
 noopito -package=your/module/pkg -interface=InterfaceName -output=./mocks
@@ -23,7 +23,7 @@ This will create `interfacename_noop.go` in the output directory containing a st
 Add a `//go:generate` directive near the interface definition:
 
 ```go
-//go:generate noopito -package=your/module/pkg -interface=InterfaceName -output=./mocks
+//go:generate noopito -interface=InterfaceName -output=./mocks
 ```
 
 Then run `go generate ./...` to produce the file automatically.

--- a/cmd/noopito/main.go
+++ b/cmd/noopito/main.go
@@ -3,21 +3,68 @@ package main
 import (
 	"flag"
 	"log"
+	"os"
+	"path"
+	"path/filepath"
+
+	"golang.org/x/mod/modfile"
 
 	"github.com/AbdouB/noopito/internal/generator"
 )
 
 func main() {
-	pkg := flag.String("package", "", "package import path")
+	pkg := flag.String("package", "", "package import path (defaults to current package)")
 	iface := flag.String("interface", "", "interface name")
 	outDir := flag.String("output", ".", "output directory")
 	flag.Parse()
 
-	if *pkg == "" || *iface == "" {
-		log.Fatal("package and interface flags are required")
+	if *iface == "" {
+		log.Fatal("interface flag is required")
 	}
 
-	if err := generator.GenerateNoOp(*pkg, *iface, *outDir); err != nil {
+	pkgPath := *pkg
+	if pkgPath == "" {
+		var err error
+		pkgPath, err = currentPackage()
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+
+	if err := generator.GenerateNoOp(pkgPath, *iface, *outDir); err != nil {
 		log.Fatal(err)
 	}
+}
+
+func currentPackage() (string, error) {
+	wd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+
+	gomod := os.Getenv("GOMOD")
+	if gomod == "" {
+		return ".", nil
+	}
+
+	data, err := os.ReadFile(gomod)
+	if err != nil {
+		return "", err
+	}
+
+	mf, err := modfile.Parse(gomod, data, nil)
+	if err != nil {
+		return "", err
+	}
+
+	modDir := filepath.Dir(gomod)
+	rel, err := filepath.Rel(modDir, wd)
+	if err != nil {
+		return "", err
+	}
+	rel = filepath.ToSlash(rel)
+	if rel == "." {
+		return mf.Module.Mod.Path, nil
+	}
+	return path.Join(mf.Module.Mod.Path, rel), nil
 }

--- a/go.mod
+++ b/go.mod
@@ -2,9 +2,9 @@ module github.com/AbdouB/noopito
 
 go 1.23.8
 
-require golang.org/x/tools v0.34.0
-
 require (
-	golang.org/x/mod v0.25.0 // indirect
-	golang.org/x/sync v0.15.0 // indirect
+	golang.org/x/mod v0.25.0
+	golang.org/x/tools v0.34.0
 )
+
+require golang.org/x/sync v0.15.0 // indirect


### PR DESCRIPTION
## Summary
- detect current module path if `-package` is omitted
- update README to describe new behaviour
- tidy go.mod

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685b04ccff2083248794e96112befe78