### PR TITLE
Add instructions for remote install/run

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,17 @@
 
 ## Installation
 
+Install the CLI directly from GitHub:
+
 ```bash
-go install ./cmd/noopito
+go install github.com/AbdouB/noopito/cmd/noopito@latest
+```
+
+Run the tool without installing it using `go run`:
+
+```bash
+go run github.com/AbdouB/noopito/cmd/noopito@latest \
+  -package=your/module/pkg -interface=InterfaceName -output=./mocks
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 
 ## Installation
 
-Install the CLI directly from GitHub:
-
 ```bash
 go install github.com/AbdouB/noopito/cmd/noopito@latest
 ```


### PR DESCRIPTION
## Summary
- show how to install noopito directly from GitHub
- remove old `go install ./cmd/noopito` example
- add an example of running the tool via `go run`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685b049135d48324865152d99f707239